### PR TITLE
fix: remove configurable LLM function rate limit

### DIFF
--- a/src/python/run.py
+++ b/src/python/run.py
@@ -72,9 +72,6 @@ def llm_function(creative=False):
 
         @functools.wraps(func)
         async def wrapper(*args, **kwargs):
-            if CONFIG.get("llm_function_rate_limited"):
-                raise LLMFunctionLimitExceededException()
-
             if len(args) > len(input_params):
                 raise ValueError("Too many positional arguments.")
 


### PR DESCRIPTION
Since switching to the postMessage mechanism, this is now obsolete and should be done on the parent side instead.