### PR TITLE
refactor(apps): protocol

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -85,9 +85,14 @@ const ALLOWED_ORIGINS = (import.meta.env.VITE_ALLOWED_FRAME_ANCESTORS ?? '').spl
     app.kernel._worker.addEventListener('message', (event: MessageEvent) => {
       const data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
       switch (data.type) {
+        case 'bee:ready':
+          ALLOWED_ORIGINS.forEach((origin: string) => parent.postMessage({ type: 'bee:ready' }, origin))
+          return;
+
         case 'bee:request':
           ALLOWED_ORIGINS.forEach((origin: string) => parent.postMessage(data, origin));
           return;
+
         default:
           return;
       }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -11,6 +11,7 @@ interface AppState {
   config: {
     canFixError: boolean
   },
+  ancestorOrigin: string,
 }
 
 // Page is loaded directly
@@ -26,12 +27,18 @@ const ALLOWED_ORIGINS = (import.meta.env.VITE_ALLOWED_FRAME_ANCESTORS ?? '').spl
     },
     theme: 'light',
     fullscreen: false,
+    ancestorOrigin: ALLOWED_ORIGINS[0],
   };
 
   let app: any;
 
   async function updateState(stateChange: Partial<AppState>) {
     const oldState = { ...state };
+
+    // validate ancestorOrigin
+    if(!ALLOWED_ORIGINS.includes(stateChange.ancestorOrigin)) stateChange.ancestorOrigin = undefined;
+
+    // update state
     state = { ...state, ...stateChange };
 
     // set fullscreen
@@ -86,11 +93,11 @@ const ALLOWED_ORIGINS = (import.meta.env.VITE_ALLOWED_FRAME_ANCESTORS ?? '').spl
       const data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
       switch (data.type) {
         case 'bee:ready':
-          ALLOWED_ORIGINS.forEach((origin: string) => parent.postMessage({ type: 'bee:ready' }, origin))
+          parent.postMessage({ type: 'bee:ready' }, state.ancestorOrigin);
           return;
 
         case 'bee:request':
-          ALLOWED_ORIGINS.forEach((origin: string) => parent.postMessage(data, origin));
+          parent.postMessage(data, state.ancestorOrigin);
           return;
 
         default:

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -108,18 +108,6 @@ const ALLOWED_ORIGINS = (import.meta.env.VITE_ALLOWED_FRAME_ANCESTORS ?? '').spl
     }
 
     switch (data.type) {
-      case 'bee:setFullscreen':
-        updateState({ fullscreen: data.value });
-        return;
-
-      case 'bee:updateTheme':
-        updateState({ theme: data.theme });
-        return;
-
-      case 'bee:updateCode':
-        updateState({ code: data.code, config: data.config })
-        return;
-
       case 'bee:response':
         app.kernel._worker.postMessage(data);
         return;

--- a/src/python/run.py
+++ b/src/python/run.py
@@ -158,7 +158,7 @@ def error_fragment(error_text):
             st.write("🛠️ The error is being fixed...")
         else:
             st.write("🤯 An error occurred while executing the app.")
-            if CONFIG.get("can_fix_error"):
+            if CONFIG.get("canFixError"):
                 if st.button("Try to fix this error", icon="🛠️", type="primary"):
                     request("fix_error", { "errorText": error_text })
                     st.session_state._bee_fixing_error = True

--- a/src/python/run.py
+++ b/src/python/run.py
@@ -160,7 +160,7 @@ def error_fragment(error_text):
             st.write("🤯 An error occurred while executing the app.")
             if CONFIG.get("can_fix_error"):
                 if st.button("Try to fix this error", icon="🛠️", type="primary"):
-                    js.postMessage(json.dumps({"type": "bee:reportError", "errorText": error_text}))
+                    request("fix_error", { "errorText": error_text })
                     st.session_state._bee_fixing_error = True
                     st.rerun(scope="fragment")
             st.expander("Error details").code(error_text, language=None)

--- a/src/python/run.py
+++ b/src/python/run.py
@@ -232,6 +232,7 @@ def patch_streamlit():
 
 
 async def run():
+    js.postMessage(json.dumps({ "type": "bee:ready" }))
     try:
         code = pathlib.Path("app.py").read_text()
         if st.session_state.get("_bee_last_code") != code:


### PR DESCRIPTION
These PRs need to be merged and deployed together:
- https://github.com/i-am-bee/bee-usercontent-site/pull/37
- https://github.com/i-am-bee/bee-ui/pull/171
- https://github.com/i-am-bee/bee-artifacts-site/pull/23

Changes (in all these PRs):
- Simplify messaging and state handling -- synchronize a single state object between apps
- Use the request mechanism for "Fix error"
- Send ready event as soon as the app starts running (perceptively faster app load)
- Track ancestor origin, avoid a barrage of mismatched origin warnings in console
- Properly sync the sandboxed frame if it reloads by itself (useful in dev)
- Unify naming in some cases